### PR TITLE
Publish JitPack artifact to mavenLocal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,3 +43,13 @@ gradlePlugin {
         }
     }
 }
+
+publishing {
+    publications {
+        mavenPublication(MavenPublication) {
+            from components.java
+            groupId "com.github.mxenabled.coppuccino"
+            artifactId "com.github.mxenabled.coppuccino.gradle.plugin"
+        }
+    }
+}


### PR DESCRIPTION
# Summary of Changes

This publishes a local JitPack artifact to mavenLocal after running the `./gradlew publishToMavenLocal` command. This enables JitPack to publish a version of the artifact we can consume remotely as well as a version we can consume locally for testing.

## Public API Additions/Changes

None.

## Downstream Consumer Impact

Allows local development to publish and consume local versions of Coppuccino.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
