### PR TITLE
Add JitPack instructions to build.gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,19 @@ Plugins:
 
 ## Installing
 
-```
+Coppuccino is hosted via [JitPack](https://jitpack.io/p/mxenabled/coppuccino). To import it into your project,
+configure the JitPack repository in your `build.gradle`.
+
+```groovy
 plugins {
-  id: "coppuccino"
+  id: "coppuccino" version "x.x.x"
+}
+
+allprojects {
+    repositories {
+        ...
+        maven { url 'https://jitpack.io' }
+    }
 }
 ```
 


### PR DESCRIPTION
# Summary of Changes

Adds instructions to the README for configuring the JitPack repository in order to pull in Coppuccino.

## Public API Additions/Changes

None.

## Downstream Consumer Impact

Better documentation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
