### PR TITLE
Disable codenarc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Plugins:
   * [Pmd](https://docs.gradle.org/current/userguide/pmd_plugin.html)
   * [Spotbugs](https://github.com/spotbugs/spotbugs-gradle-plugin)
   * [Checkstyle](https://docs.gradle.org/current/userguide/checkstyle_plugin.html)
-  * [CodeNarc](https://docs.gradle.org/current/userguide/codenarc_plugin.html)
 
 ## Installing
 

--- a/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
@@ -85,6 +85,7 @@ class CoppuccinoPlugin implements Plugin<Project> {
           quality {
             checkstyleVersion = '8.29'
             checkstyle = true
+            codenarc = false
             pmd = true
             spotbugs = true
             configDir = "${coppuccino.rootDir}.coppuccino"


### PR DESCRIPTION



# Summary of Changes

This disables codenarc. It seems to enable itself when it detects
groovy in src/main. The rules conflict with MX's Spotless formatting
rules.

We may consider exposing a configuration that allows it to be enabled
when we can sync up the rules.

Fixes # (issue)

## Public API Additions/Changes

Please include a description of any new or modified publicly available classes and/or methods (if applicable).

## Downstream Consumer Impact

This should ot impact downstream consumers.

# How Has This Been Tested?

I included an updated version in a project that that contained a lot of groovy code. The codenarc checks did not fire anymore. Also used to check an existing project. May of the rules failed the build, as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
