### PR TITLE
Remove double version reference in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
 project.description     = "Java style, standard, and safety enforcement"
 project.group           = "com.mx.coppuccino"
-project.version         = "1.1.2"
+project.version         = rootProject.version
 
 project.ext.name        = "coppuccino"
 project.ext.pluginId    = "com.mx.coppuccino"


### PR DESCRIPTION
# Summary of Changes

This reduces the requirement of maintaining two version numbers in the build.gradle.

## Public API Additions/Changes

None.

## Downstream Consumer Impact

None. Only affects maintainers.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
