### PR TITLE
Remove dependency check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     implementation "com.diffplug.spotless:spotless-plugin-gradle:6.5.2"
     implementation "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.10.0"
     implementation "org.kordamp.gradle:jacoco-gradle-plugin:0.39.0"
-    implementation "org.owasp:dependency-check-gradle:6.5.3"
     testImplementation group: "junit", name: "junit", version: "4.13"
 }
 

--- a/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.ComponentSelection
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.testing.Test
-import org.owasp.dependencycheck.gradle.DependencyCheckPlugin
 import org.kordamp.gradle.plugin.jacoco.JacocoPlugin
 import ru.vyarus.gradle.plugin.quality.QualityPlugin
 import io.gitlab.arturbosch.detekt.DetektPlugin
@@ -39,7 +38,6 @@ class CoppuccinoPlugin implements Plugin<Project> {
     // Register extensions for config DSL
     def coppuccino = project.extensions.create('coppuccino', CoppuccinoPluginExtension)
     def coverage = project.extensions.coppuccino.extensions.create('coverage', CoppuccinoCoverageExtension)
-    def dependencies = project.extensions.coppuccino.extensions.create('dependencies', CoppuccinoDependenciesExtension)
     def kotlinEx = project.extensions.coppuccino.extensions.create('kotlin', CoppuccinoKotlinExtension)
 
     project.plugins.withType(JavaPlugin) {
@@ -56,28 +54,7 @@ class CoppuccinoPlugin implements Plugin<Project> {
           project.plugins.apply(DetektPlugin)
         }
         project.plugins.apply(JacocoPlugin)
-        project.plugins.apply(DependencyCheckPlugin)
         project.configure(project) {
-
-          // **************************************
-          // Dependency Check Scanning
-          // **************************************
-          dependencyCheck {
-            data { directory=".dependency-check-data" }
-            cveValidForHours=24
-            failBuildOnCVSS=4
-            format='HTML'
-            skipConfigurations=[
-                    'checkstyle',
-                    'detekt',
-                    'detektPlugins',
-                    'pmd',
-                    'spotbugs',
-                    'spotbugsPlugins',
-                    'spotbugsSlf4j'
-            ]
-            suppressionFile="${coppuccino.rootDir}dependency_suppression.xml"
-          }
 
           // **************************************
           // Quality plugin configuration
@@ -212,26 +189,6 @@ class CoppuccinoPlugin implements Plugin<Project> {
                   def startItem = '|  ', endItem = '  |'
                   def repeatLength = startItem.length() + output.length() + endItem.length()
                   println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
-                }
-              }
-            }
-          }
-
-          if (dependencies.lockingEnabled) {
-            dependencyLocking { lockAllConfigurations() }
-          }
-
-          if (dependencies.excludePreReleaseVersions) {
-            configurations.all {
-              resolutionStrategy {
-                cacheDynamicVersionsFor 0, "seconds"
-                componentSelection {
-                  // ignore all versions that end with 'pre'
-                  all { ComponentSelection selection ->
-                    if (selection.candidate.version.endsWith('pre')) {
-                      selection.reject("pre versions are ignored")
-                    }
-                  }
                 }
               }
             }

--- a/src/main/groovy/com/mx/coppuccino/CoppuccinoPluginExtension.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CoppuccinoPluginExtension.groovy
@@ -28,13 +28,6 @@ class CoppuccinoCoverageExtension {
   ]
 }
 
-class CoppuccinoDependenciesExtension {
-  // Enable Dependency locking on all configurations
-  boolean lockingEnabled = true
-
-  // Ignore pre releases in dynamic version resolution
-  boolean excludePreReleaseVersions = true
-}
 
 class CoppuccinoKotlinExtension {
   // Disable kotlin support by default


### PR DESCRIPTION
# Summary of Changes

Removing the dependency check logic from Coppuccino as it now exists in Hush.

Fixes # (issue)

## Public API Additions/Changes

N/A

## Downstream Consumer Impact

Once merged, users will no longer be able to rely upon Coppuccino for the dependency check (and analyze / CVE report) task.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
