### PR TITLE
Enable JavaDoc processing for UnusedFile check

### DIFF
--- a/src/main/resources/com/mx/coppuccino/config/checkstyle/checkstyle.xml
+++ b/src/main/resources/com/mx/coppuccino/config/checkstyle/checkstyle.xml
@@ -107,7 +107,7 @@
     <!-- defaults to sun.* packages -->
     <module name="RedundantImport" />
     <module name="UnusedImports">
-      <property name="processJavadoc" value="false" />
+      <property name="processJavadoc" value="true" /> <!-- This counts an import as used if it is referenced in JavaDocs in the file -->
     </module>
 
     <!-- Checks for Size Violations.                    -->


### PR DESCRIPTION
# Summary of Changes

* Set processJavaDoc to true in checkstyle.xml

## Downstream Consumer Impact

Impact unlikely

# How Has This Been Tested?

Tested with SDK libraries

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
