### PR TITLE
Update detekt plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,31 @@
-**/.DS_Store
+/target/
+.DS_Store
 
 ### VS Code ###
 .vscode/
 
 ### IntelliJ IDEA ###
 .idea
-**.iws
-**.ipr
-**.iml
-out/
+*.iws
+*.iml
+*.ipr
+*.hprof
+/out/**
 
-### Mem Dumps ###
-dump.rdb
+### NetBeans ###
+/nbproject/private/
+/build/
+/nbbuild/
+/dist/
+/nbdist/
 
-## gradle ##
-build
-.gradle/
+## Gradle ##
+.gradle
+**/build/
+!src/**/build/
 
-.coppuccino/
+## Coppuccino ##
+.coppuccino
+
+## Hush ##
 .dependency-check-data

--- a/build.gradle
+++ b/build.gradle
@@ -1,37 +1,34 @@
-
 plugins {
-    id "com.github.mxenabled.hush" version "2.3.0"
-    id "com.github.mxenabled.vogue" version "1.0.1"
-    id "java-gradle-plugin"
-    id "java-library"
-    id "maven-publish"
-    id "groovy"
-    id "com.github.ben-manes.versions" version "0.42.0"
+  id "com.github.mxenabled.hush" version "2.3.1"
+  id "com.github.mxenabled.vogue" version "1.0.1"
+  id "groovy"
+  id "java-gradle-plugin"
+  id "java-library"
+  id "maven-publish"
+  id "com.github.ben-manes.versions" version "0.43.0"
 }
 
 group "com.mx.coppuccino"
-version "3.1.2"
-
+version "3.1.3"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 repositories {
-    gradlePluginPortal()
-    mavenLocal()
+  gradlePluginPortal()
+  mavenLocal()
 }
 
 dependencies {
-    // Need to keep at 4.7.0. 4.8.0 is not compatible with Java 8.
-    implementation "ru.vyarus:gradle-quality-plugin:4.7.0"
-    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.9'
-    // Need to keep at 6.6.0 until issues with M1 Macs is addressed.
-    implementation ("com.diffplug.spotless:spotless-plugin-gradle:6.6.0") {
-        exclude group: "com.google.googlejavaformat", module: "google-java-format-parent"
-    }
-    implementation "com.google.googlejavaformat:google-java-format-parent:1.15.0"
-    implementation "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0"
-    implementation "org.kordamp.gradle:jacoco-gradle-plugin:0.47.0"
-    testImplementation group: "junit", name: "junit", version: "4.13.2"
+  // Need to keep at 4.7.0. 4.8.0 is not compatible with Java 8.
+  implementation "ru.vyarus:gradle-quality-plugin:4.7.0"
+  implementation "com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.13"
+  // Need to keep at 6.6.0 until issues with M1 Macs is addressed.
+  implementation("com.diffplug.spotless:spotless-plugin-gradle:6.6.0") {
+    exclude group: "com.google.googlejavaformat", module: "google-java-format-parent"
+  }
+  implementation "com.google.googlejavaformat:google-java-format-parent:1.15.0"
+  implementation "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.22.0-RC2"
+  implementation "org.kordamp.gradle:jacoco-gradle-plugin:0.47.0"
 }
 
 project.description     = "Java style, standard, and safety enforcement"
@@ -43,14 +40,14 @@ project.ext.pluginId    = "com.mx.coppuccino"
 project.ext.url         = "https://github.com/mxenabled/Coppuccino"
 
 gradlePlugin {
-    plugins {
-        coppuccinoPlugin {
-            id = project.pluginId
-            implementationClass = "com.mx.coppuccino.CoppuccinoPlugin"
-        }
-        coppuccinoJitPackPlugin {
-            id = "com.github.mxenabled.coppuccino"
-            implementationClass = "com.mx.coppuccino.CoppuccinoPlugin"
-        }
+  plugins {
+    coppuccinoPlugin {
+      id = project.pluginId
+      implementationClass = "com.mx.coppuccino.CoppuccinoPlugin"
     }
+    coppuccinoJitPackPlugin {
+      id = "com.github.mxenabled.coppuccino"
+      implementationClass = "com.mx.coppuccino.CoppuccinoPlugin"
+    }
+  }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,9 +2,8 @@ pluginManagement {
   repositories {
     gradlePluginPortal()
     mavenLocal()
-    maven {
-      url 'https://jitpack.io'
-    }
+    maven { url "https://jitpack.io" }
   }
 }
-rootProject.name = 'coppuccino'
+
+rootProject.name = "coppuccino"

--- a/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
@@ -117,10 +117,10 @@ class CoppuccinoPlugin implements Plugin<Project> {
               excludes: "${coppuccino.rootDir}.*build.*,.*/resources/.*,.*/tmp/.*"
             }
           }
+
           // **************************************
           // JaCoCo test coverage configuration
           // **************************************
-
           test.finalizedBy jacocoTestReport
           check.dependsOn jacocoTestCoverageVerification
 
@@ -217,7 +217,6 @@ class CoppuccinoPlugin implements Plugin<Project> {
 
           project.tasks.spotlessGroovy.dependsOn(compileJava, compileTestGroovy)
           project.tasks.spotlessJava.dependsOn(compileJava, compileTestGroovy, spotlessGroovy)
-
         }
       }
     }

--- a/src/main/resources/com/mx/coppuccino/config/detekt/detekt.yml
+++ b/src/main/resources/com/mx/coppuccino/config/detekt/detekt.yml
@@ -396,8 +396,6 @@ potential-bugs:
       - 'java.util.HashSet'
       - 'java.util.LinkedHashMap'
       - 'java.util.HashMap'
-  DuplicateCaseInWhenExpression:
-    active: true
   ElseCaseInsteadOfExhaustiveWhen:
     active: false
   EqualsAlwaysReturnsTrueOrFalse:
@@ -439,15 +437,10 @@ potential-bugs:
   MissingPackageDeclaration:
     active: false
     excludes: ['**/*.kts']
-  MissingWhenCase:
-    active: true
-    allowElseExpression: true
   NullCheckOnMutableProperty:
     active: false
   NullableToStringCall:
     active: false
-  RedundantElseInWhen:
-    active: true
   UnconditionalJumpStatementInLoop:
     active: false
   UnnecessaryNotNullOperator:
@@ -515,12 +508,6 @@ style:
     methods:
       - 'kotlin.io.print'
       - 'kotlin.io.println'
-  ForbiddenPublicDataClass:
-    active: true
-    excludes: ['**']
-    ignorePackages:
-      - '*.internal'
-      - '*.internal.*'
   ForbiddenVoid:
     active: false
     ignoreOverridden: false
@@ -530,12 +517,6 @@ style:
     ignoreOverridableFunction: true
     ignoreActualFunction: true
     excludedFunctions: []
-  LibraryCodeMustSpecifyReturnType:
-    active: true
-    excludes: ['**']
-  LibraryEntitiesShouldNotBePublic:
-    active: true
-    excludes: ['**']
   LoopWithTooManyJumpStatements:
     active: true
     maxJumpCount: 1


### PR DESCRIPTION
# Summary of Changes

* Upgrade detekt plugin to 1.22.0-RC2
* Remove deprecated rules (detekt)
* Upgrade spotbugs and versions plugins
* Bump version to 3.1.3

## Downstream Consumer Impact

Fixes a bug where the detekt task would fail in Kotlin projects (with `CoppuccinoKotlinExtension` enabled).

# How Has This Been Tested?

I pulled the updated version into both Java and Kotlin projects and verified it is working as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
