### PR TITLE
Clean up minor spotbugs report formatting issue

### DIFF
--- a/src/main/groovy/com/mx/coppuccino/SpotbugsConsoleReporter.groovy
+++ b/src/main/groovy/com/mx/coppuccino/SpotbugsConsoleReporter.groovy
@@ -69,8 +69,8 @@ class SpotbugsConsoleReporter {
         out.style(Style.FailureHeader)
             .text("[${plugin}${cat[bug.@category]} | ${bugType}] $pkg(${cls}:${srcPosition})  ")
             .style(Style.Identifier).println("[priority ${bug.@priority} / rank ${bug.@rank}]")
-            .style(Style.Failure).println("> Violation: ").style(Style.Error).println("${msg.text()}$NL")
-            .style(Style.Failure).println("> Description: ").style(Style.Error).println("  ${description}$NL$NL")
+            .style(Style.Failure).println("> Violation: ").style(Style.Error).println("  ${msg.text()}")
+            .style(Style.Failure).println("> Details: ").style(Style.Error).println("  ${description}$NL")
       }
 
       generateHtmlReport(reportFile)


### PR DESCRIPTION
# Summary of Changes

Minor report style tweak:

<img width="1172" alt="CleanShot 2023-01-05 at 09 25 27@2x" src="https://user-images.githubusercontent.com/12796/210830262-5dbc0e27-a38e-4105-8c29-5517700ef7ae.png">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
