### PR TITLE
Fix problem copying config files in multi-module projects

### DIFF
--- a/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
@@ -45,7 +45,7 @@ class CoppuccinoPlugin implements Plugin<Project> {
 
     project.plugins.withType(JavaPlugin) {
       project.afterEvaluate {
-        def initCopConfig = new CopyCopConfig(coppuccino.rootDir)
+        def initCopConfig = new CopyCopConfig(coppuccino.rootDir, project)
         initCopConfig.run()
       }
 

--- a/src/main/groovy/com/mx/coppuccino/CopyCopConfig.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CopyCopConfig.groovy
@@ -16,20 +16,22 @@
 package com.mx.coppuccino
 
 import groovy.transform.CompileStatic
+import org.gradle.api.Project
+
 import java.nio.file.Paths
 
 @CompileStatic
 class CopyCopConfig {
 
   String projectRoot
+  Project project
 
-  CopyCopConfig(String projectRoot) {
+  CopyCopConfig(String projectRoot, Project project) {
     this.projectRoot = projectRoot
+    this.project = project
   }
 
   void run() {
-    ensureProjectDirectory(".coppuccino/")
-
     copyConfigFile("/com/mx/coppuccino/config/pmd/pmd.xml", ".coppuccino/pmd/pmd.xml")
     copyConfigFile("/com/mx/coppuccino/config/checkstyle/checkstyle.xml",".coppuccino/checkstyle/checkstyle.xml" )
     copyConfigFile("/com/mx/coppuccino/config/spotbugs/exclude.xml", ".coppuccino/spotbugs/exclude.xml")
@@ -40,16 +42,15 @@ class CopyCopConfig {
 
   private void copyConfigFile(String resourcePath, String dest) {
     File target = new File(Paths.get(projectRoot, dest).toString())
-    ensureProjectDirectory(target.getParentFile().toPath().toString())
+    ensureDirectory(target.getParentFile())
     InputStream stream = getClass().getResourceAsStream(resourcePath)
     target.text = ''
     target << stream.text
   }
 
-  private void ensureProjectDirectory(String pathStr) {
-    File path = new File(Paths.get(projectRoot, pathStr).toString())
-
+  private void ensureDirectory(File path) {
     if (!path.exists()) {
+      project.logger.info("Coppuccino: creating configuration path: ${path.toString()}")
       path.mkdirs()
     }
   }


### PR DESCRIPTION
# Summary of Changes

Fix issue creating config files in multi-module projects when they don't already exist.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
