### PR TITLE
fix: explicitly create .coppuccino directory

### DIFF
--- a/src/main/groovy/com/mx/coppuccino/CopyCopConfig.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CopyCopConfig.groovy
@@ -32,6 +32,11 @@ class CopyCopConfig {
   }
 
   void run() {
+    File configDir = new File(Paths.get(".coppuccino").toString())
+    if (!configDir.exists()) {
+      configDir.mkdir()
+    }
+
     copyConfigFile("/com/mx/coppuccino/config/pmd/pmd.xml", ".coppuccino/pmd/pmd.xml")
     copyConfigFile("/com/mx/coppuccino/config/checkstyle/checkstyle.xml",".coppuccino/checkstyle/checkstyle.xml" )
     copyConfigFile("/com/mx/coppuccino/config/spotbugs/exclude.xml", ".coppuccino/spotbugs/exclude.xml")


### PR DESCRIPTION
# Summary of Changes

Add check and code to explicitly create the .coppuccino directory. This fixes a build issue when the .coppuccino directory is not present.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
