### PR TITLE
fix: treat -rc. versions as pre-release

### DIFF
--- a/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
@@ -241,6 +241,9 @@ class CoppuccinoPlugin implements Plugin<Project> {
                     if (selection.candidate.version.endsWith('pre')) {
                       selection.reject("pre versions are ignored")
                     }
+                    if (selection.candidate.version.contains('-rc.')) {
+                      selection.reject("release candidate versions are ignored")
+                    }
                   }
                 }
               }


### PR DESCRIPTION
Treat versions with `-rc.` as pre-releases. They will be excluded unless `excludePreReleaseVersions` is set to false.