### PR TITLE
feat: support config overrides and the disabling of checkstyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ _In build.gradle_
 ```
 coppuccino {
   rootDir = "" # Relative path to project root
+  overwriteConfigs = true # Set to false to allow a project to manage its own copy of configs (e.g. spotbugs/exclude.xml) 
   coverage {
     minimumCoverage = 0.0   # Required percentage of test code coverage.
     excludes [ # Package paths to exclude from coverage calculation
@@ -56,6 +57,9 @@ coppuccino {
   dependencies {
     lockingEnabled = true
     excludePreReleaseVersions = true # Set to false to allow for #.#.3.pre release versions to be included in --write-locks
+  }
+  java {
+    enabled = true # Set to false to disable checkstyle (e.g. for projects that have no java files)
   }
   kotlin {
     enabled = false # Set to true to enable kotlin linting with Detekt

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
-  id "com.github.mxenabled.hush" version "2.3.5"
-  id "com.github.mxenabled.vogue" version "1.0.2"
+  id "com.github.mxenabled.vogue" version "1.0.3"
   id "groovy"
   id "java-gradle-plugin"
   id "java-library"

--- a/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
@@ -41,11 +41,12 @@ class CoppuccinoPlugin implements Plugin<Project> {
     def coppuccino = project.extensions.create('coppuccino', CoppuccinoPluginExtension)
     def coverage = project.extensions.coppuccino.extensions.create('coverage', CoppuccinoCoverageExtension)
     def dependencies = project.extensions.coppuccino.extensions.create('dependencies', CoppuccinoDependenciesExtension)
+    def javaEx = project.extensions.coppuccino.extensions.create('java', CoppuccinoJavaExtension)
     def kotlinEx = project.extensions.coppuccino.extensions.create('kotlin', CoppuccinoKotlinExtension)
 
     project.plugins.withType(JavaPlugin) {
       project.afterEvaluate {
-        def initCopConfig = new CopyCopConfig(coppuccino.rootDir, project)
+        def initCopConfig = new CopyCopConfig(coppuccino.rootDir, project, coppuccino.overwriteConfigs)
         initCopConfig.run()
       }
 
@@ -65,7 +66,7 @@ class CoppuccinoPlugin implements Plugin<Project> {
           // **************************************
           quality {
             checkstyleVersion = '8.29'
-            checkstyle = true
+            checkstyle = javaEx.enabled
             codenarc = false
             pmd = true
             spotbugs = false

--- a/src/main/groovy/com/mx/coppuccino/CoppuccinoPluginExtension.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CoppuccinoPluginExtension.groovy
@@ -17,6 +17,7 @@ package com.mx.coppuccino
 
 class CoppuccinoPluginExtension {
   String rootDir = ""
+  boolean overwriteConfigs = true
 }
 
 class CoppuccinoCoverageExtension {
@@ -34,6 +35,11 @@ class CoppuccinoDependenciesExtension {
 
   // Ignore pre releases in dynamic version resolution
   boolean excludePreReleaseVersions = true
+}
+
+class CoppuccinoJavaExtension {
+  // Enable java support by default
+  boolean enabled = true
 }
 
 class CoppuccinoKotlinExtension {

--- a/src/main/groovy/com/mx/coppuccino/CopyCopConfig.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CopyCopConfig.groovy
@@ -25,10 +25,12 @@ class CopyCopConfig {
 
   String projectRoot
   Project project
+  Boolean overwriteConfigs
 
-  CopyCopConfig(String projectRoot, Project project) {
+  CopyCopConfig(String projectRoot, Project project, Boolean overwriteConfigs) {
     this.projectRoot = projectRoot
     this.project = project
+    this.overwriteConfigs = overwriteConfigs
   }
 
   void run() {
@@ -48,6 +50,11 @@ class CopyCopConfig {
   private void copyConfigFile(String resourcePath, String dest) {
     File target = new File(Paths.get(projectRoot, dest).toString())
     ensureDirectory(target.getParentFile())
+
+    if (!overwriteConfigs && target.exists()) {
+      return
+    }
+
     InputStream stream = getClass().getResourceAsStream(resourcePath)
     target.text = ''
     target << stream.text


### PR DESCRIPTION
# Summary of Changes

Introduced an `overwriteConfigs` boolean setting to allow a project to prevent Coppuccino from overwriting any configs that it is trying to manage on its own.  By default `overwriteConfigs` is set to true, which allows the original Coppuccino behavior to ensue.  When false, if Coppuccino encounters a pre-existing config file (e.g. spotbugs/exclude.xml) it will skip updating it.  

Also added a java extension with an `enabled` flag which currently controls whether Checkstyle is enabled for the project.  This is helpful for Kotlin-based projects that have no java files yet to avoid a compilation error.

Fixes #HW2-920

## Public API Additions/Changes

The optional `overwriteConfigs` and `java.enabled` settings were introduced.  For example:

```
coppuccino {
  rootDir = "${projectDir}/"
  overwriteConfigs = false
  java {
    enabled = false
  }
}
```

## Downstream Consumer Impact

This should not impact any downstream consumers as the new settings are optional and the default behaviour should be as before.

# How Has This Been Tested?

- [x] Tested `overwriteConfigs` not specified
- [x] Tested `overwriteConfigs` set to true
- [x] Tested `overwriteConfigs` set to false
- [x] Tested `java.enabled` not specified
- [x] Tested `java.enabled` set to true
- [x] Tested `java.enabled` set to false
- [x] Tested across a couple projects

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
