### PR TITLE
fix: set jdk version in jitpack config

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,6 @@
+jdk:
+  - openjdk17
+before_install:
+  - sdk list java
+  - sdk install java 17.0.3-amzn
+  - sdk use java 17.0.3-amzn


### PR DESCRIPTION
# Summary of Changes

Adds `jitpack.yml` and sets the JDK version to Java 17.

ref: https://github.com/jitpack/jitpack.io/blob/main/building/_index.en.md#java-version

## Public API Additions/Changes

none

## Downstream Consumer Impact

none

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
