### PR TITLE
fix: remove unnecessary jitpack configs

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,2 @@
 jdk:
   - openjdk17
-before_install:
-  - sdk list java
-  - sdk install java 17.0.3-amzn
-  - sdk use java 17.0.3-amzn


### PR DESCRIPTION
# Summary of Changes

Follow up to https://github.com/mxenabled/coppuccino/pull/53

This removes the `before_script` config in `jitpack.yml` which is not necessary. Based on the [4.0.1 build log](https://jitpack.io/com/github/mxenabled/coppuccino/4.0.1/build.log), setting the `jdk` to `openjdk17` already adds `sdk install java 17.0.12-oracle;sdk use java 17.0.12-oracle` to the before script.

Additionally, using a custom before script to set the specific JDK version is a fragile solution, since [SDKMan](https://sdkman.io/) only has the latest minor version for each LTS version and distribution.

## Public API Additions/Changes

none

## Downstream Consumer Impact

none

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
