### PR TITLE
build: upgrade spotless to version 7.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.mxenabled.vogue" version "1.0.3"
+  id "com.github.mxenabled.vogue" version "1.+"
   id "groovy"
   id "java-gradle-plugin"
   id "java-library"
@@ -9,8 +9,8 @@ plugins {
 
 group "com.mx.coppuccino"
 version "4.0.3" // x-release-please-version
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 repositories {
   gradlePluginPortal()
@@ -20,11 +20,7 @@ repositories {
 dependencies {
   implementation "ru.vyarus:gradle-quality-plugin:4.9.0"
   implementation "com.github.spotbugs.snom:spotbugs-gradle-plugin:5.2.5"
-  // Need to keep at 6.6.0 until issues with M1 Macs is addressed.
-  implementation("com.diffplug.spotless:spotless-plugin-gradle:6.6.0") {
-    exclude group: "com.google.googlejavaformat", module: "google-java-format-parent"
-  }
-  implementation "com.google.googlejavaformat:google-java-format-parent:1.23.0"
+  implementation "com.diffplug.spotless:spotless-plugin-gradle:7.0.2"
   implementation "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.22.0"
   implementation "org.kordamp.gradle:jacoco-gradle-plugin:0.54.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,0 @@
-org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
@@ -83,14 +83,15 @@ class CoppuccinoPlugin implements Plugin<Project> {
           // **************************************
           spotless {
             groovy {
-              importOrder('java', 'javax', 'edu', 'com', 'org', 'brave', 'io', 'reactor')
-              greclipse('4.19.0').configFile("${coppuccino.rootDir}.coppuccino/spotless/eclipse-formatter.xml")
+              importOrder('\\#', 'java', 'javax', 'edu', '', 'com', 'org', 'brave', 'io', 'reactor', 'spock')
+              removeSemicolons()
+              greclipse().configFile("${coppuccino.rootDir}.coppuccino/spotless/eclipse-formatter.xml")
               target "**/*.gradle", "**/*.groovy"
               targetExclude "build/generated/**/*.*", ".gradle/**/*.*", "build/generatedsources/**/*.*"
             }
 
             java {
-              importOrder ('java', 'javax', 'edu', 'com', 'org', 'brave', 'io', 'reactor')
+              importOrder ('\\#', 'java', 'javax', 'lombok', 'edu', '', 'com', 'org', 'brave', 'io', 'reactor')
               removeUnusedImports()
               eclipse().configFile("${coppuccino.rootDir}.coppuccino/spotless/eclipse-formatter.xml")
               target "**/*.java"


### PR DESCRIPTION
# Summary of Changes

Upgrades spotless gradle plugin to the latest version (7.0.2). This version only supports Java 11 and above, so I had to update the compatible version in build.gradle to `JavaVersion.VERSION_11`. 

This version adds the groovy formatting option `removeSemicolons` which removes unnecessary ending semicolons from groovy files. This will now be applied when using `spotlessApply`.

This version also changes how import ordering is updated by `spotlessApply`. I updated the import order for groovy and java files to behave similar to the previous functionality (though there may be some minor differences).

Additionally, this version of spotless fixes a bug that required us to include the following gradle JVM options:

```
org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
```

These are no longer needed in projects that use Coppuccino and can be removed.

# How Has This Been Tested?

I pulled a snapshot version of this change into a path connector and accessor. I verified that I was able to build successfully and that `spotlessApply` works as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
