### PR TITLE
feat(spotless): use latest ktlint version with custom config

### DIFF
--- a/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CoppuccinoPlugin.groovy
@@ -91,7 +91,7 @@ class CoppuccinoPlugin implements Plugin<Project> {
             }
 
             java {
-              importOrder ('\\#', 'java', 'javax', 'lombok', 'edu', 'com', 'org', 'brave', 'io', 'reactor', '')
+              importOrder('\\#', 'java', 'javax', 'lombok', 'edu', 'com', 'org', 'brave', 'io', 'reactor', '')
               removeUnusedImports()
               eclipse().configFile("${coppuccino.rootDir}.coppuccino/spotless/eclipse-formatter.xml")
               target "**/*.java"
@@ -100,13 +100,7 @@ class CoppuccinoPlugin implements Plugin<Project> {
 
             if (kotlinEx.enabled) {
               kotlin {
-                ktlint('0.39.0').userData(
-                    [
-                        'indent_size'             : '2',
-                        'continuation_indent_size': '2',
-                        'kotlin_imports_layout'   : 'idea'
-                    ]
-                )
+                ktlint().setEditorConfigPath("${coppuccino.rootDir}.coppuccino/spotless/.editorconfig")
               }
             }
           }
@@ -119,7 +113,7 @@ class CoppuccinoPlugin implements Plugin<Project> {
           spotbugs {
             effort = "max"
             reportLevel = "medium"
-            extraArgs = [ "-longBugCodes" ]
+            extraArgs = ["-longBugCodes"]
             excludeFilter = file("${coppuccino.rootDir}.coppuccino/spotbugs/exclude.xml")
           }
 
@@ -127,7 +121,7 @@ class CoppuccinoPlugin implements Plugin<Project> {
             doLast {
               try {
                 new SpotbugsConsoleReporter(project, coppuccino).report()
-              } catch(Exception e) {
+              } catch (Exception e) {
                 project.logger.error("Unable to generate spotbugs report", e)
               }
             }
@@ -177,9 +171,9 @@ class CoppuccinoPlugin implements Plugin<Project> {
                   minimum = coverage.minimumCoverage
                 }
                 afterEvaluate {
-                    classDirectories.setFrom(classDirectories.files.collect {
-                        fileTree(dir: it, exclude: coverage.excludes)
-                    })
+                  classDirectories.setFrom(classDirectories.files.collect {
+                    fileTree(dir: it, exclude: coverage.excludes)
+                  })
                 }
                 excludes = coverage.excludes
               }

--- a/src/main/groovy/com/mx/coppuccino/CopyCopConfig.groovy
+++ b/src/main/groovy/com/mx/coppuccino/CopyCopConfig.groovy
@@ -40,9 +40,10 @@ class CopyCopConfig {
     }
 
     copyConfigFile("/com/mx/coppuccino/config/pmd/pmd.xml", ".coppuccino/pmd/pmd.xml")
-    copyConfigFile("/com/mx/coppuccino/config/checkstyle/checkstyle.xml",".coppuccino/checkstyle/checkstyle.xml" )
+    copyConfigFile("/com/mx/coppuccino/config/checkstyle/checkstyle.xml", ".coppuccino/checkstyle/checkstyle.xml")
     copyConfigFile("/com/mx/coppuccino/config/spotbugs/exclude.xml", ".coppuccino/spotbugs/exclude.xml")
     copyConfigFile("/com/mx/coppuccino/config/spotbugs/html-report-style.xsl", ".coppuccino/spotbugs/html-report-style.xsl")
+    copyConfigFile("/com/mx/coppuccino/config/spotless/.editorconfig", ".coppuccino/spotless/.editorconfig")
     copyConfigFile("/com/mx/coppuccino/config/spotless/eclipse-formatter.xml", ".coppuccino/spotless/eclipse-formatter.xml")
     copyConfigFile("/com/mx/coppuccino/config/detekt/detekt.yml", ".coppuccino/detekt/detekt.yml")
   }

--- a/src/main/resources/com/mx/coppuccino/config/detekt/detekt.yml
+++ b/src/main/resources/com/mx/coppuccino/config/detekt/detekt.yml
@@ -542,12 +542,8 @@ style:
     active: false
   MandatoryBracesLoops:
     active: false
-  MaxLineLength:
-    active: true
-    maxLineLength: 150
-    excludePackageStatements: true
-    excludeImportStatements: true
-    excludeCommentStatements: false
+  MaxLineLength: # enforced by spotless/ktlint
+    active: false
   MayBeConst:
     active: true
   ModifierOrder:

--- a/src/main/resources/com/mx/coppuccino/config/spotless/.editorconfig
+++ b/src/main/resources/com/mx/coppuccino/config/spotless/.editorconfig
@@ -1,0 +1,29 @@
+# https://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+max_line_length = 150
+
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{kt,kts}]
+ktlint_code_style = intellij_idea
+
+ktlint_standard = enabled
+ktlint_standard_argument-list-wrapping = disabled
+ktlint_standard_binary-expression-wrapping = disabled
+ktlint_standard_class-signature = disabled
+ktlint_standard_condition-wrapping = disabled
+ktlint_standard_function-expression-body = disabled
+ktlint_standard_function-signature = disabled
+ktlint_standard_parameter-list-wrapping = disabled
+ktlint_standard_value-argument-comment = disabled
+ktlint_standard_value-parameter-comment = disabled
+
+ij_kotlin_allow_trailing_comma = false
+ij_kotlin_allow_trailing_comma_on_call_site = false


### PR DESCRIPTION
# Summary of Changes

Spotless uses [Ktlint](https://pinterest.github.io/ktlint/latest/) to perform code style checks in Kotlin projects. We previously had Ktlint locked to version `0.39.0` and provided rules via the `userData` method. However, this method was removed in a previous version of Spotless and needs to be replaced with a different configuration method.

This MR updates Ktlint to use the latest version (currently `1.5.0`) with a custom configuration. This configuration is provided in an `.editorconfig` file that contains the following rules:
```
[*]
indent_style = space
indent_size = 2
max_line_length = 150

end_of_line = lf
charset = utf-8
trim_trailing_whitespace = true
insert_final_newline = true

[*.{kt,kts}]
ktlint_code_style = intellij_idea

ktlint_standard = enabled
ktlint_standard_argument-list-wrapping = disabled
ktlint_standard_binary-expression-wrapping = disabled
ktlint_standard_class-signature = disabled
ktlint_standard_condition-wrapping = disabled
ktlint_standard_function-expression-body = disabled
ktlint_standard_function-signature = disabled
ktlint_standard_parameter-list-wrapping = disabled
ktlint_standard_value-argument-comment = disabled
ktlint_standard_value-parameter-comment = disabled

ij_kotlin_allow_trailing_comma = false
ij_kotlin_allow_trailing_comma_on_call_site = false
```

Some of the standard Ktlint rules are disabled because they are too strict and don't match commonly used patterns that exist in other projects. However, there are several new rules that are included in this version of Ktlint that weren't enforced previously. See [Ktlint Standard Rules](https://pinterest.github.io/ktlint/latest/rules/standard/) for more information.

Additionally, the Detekt `MaxLineLength` rule was replaced with an equivalent Ktlint rule. This was done because the Ktlint `max-line-length` rule is used by several other rules in the standard ruleset. The Detekt `MaxLineLength` rule is made redundant by the Ktlint `max-line-length` rule, so it has been disabled.

## Downstream Consumer Impact

These changes only affect projects with the `CoppuccinoKotlinExtension` enabled. Spotless gradle tasks will check the project's kotlin code using the updated rules. If rule violations are found, the task will fail and a description of the issue will be provided in the console. The `spotlessApply` task will apply fixes for rule violations automatically where possible.

Suppressions of the previous `MaxLineLength` rule are no longer needed and should be replaced with `@Suppress("ktlint:standard:max-line-length")` if necessary. However, the preferred change would be to correct the violation so that no suppression is needed.

# How Has This Been Tested?

I pulled these changes into multiple kotlin projects and verified `./gradlew spotlessApply` enforced the new rules and applied formatting fixes as expected. I also verified that `./gradlew clean build` completed successfully after all formatting issues were resolved.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
