### PR TITLE
fix: bump jitpack to java21 | MC-11845

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,2 @@
 jdk:
-  - openjdk17
+  - openjdk21


### PR DESCRIPTION
# Summary of Changes

Publish failed due to missing java upgrade to jitpack, this resolves that

Fixes [MC-11845](https://mxcom.atlassian.net/browse/MC-11845)

## Public API Additions/Changes

None

## Downstream Consumer Impact

Downstream consumer will need to leverage gradle 8 and java 21

# How Has This Been Tested?

Tested locally 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works


[MC-11845]: https://mxcom.atlassian.net/browse/MC-11845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ